### PR TITLE
feat: add without and only options support to update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You can activate the commands by launching the command palette (View > Command P
 | Remove packages                    | `poetry remove <package>`       | Remove packages from the current list of installed packages                            |
 | **Deprecated** Remove dev packages | `poetry remove --dev <package>` | **Deprecated**, use `Remove packages` instead. Remove dev packages                     |
 | Update all packages                | `poetry update`                 | Update all packages from the current list of installed packages                        |
+| Update all packages (with options) | `poetry update  [--options]`    | Update all packages with additional options                                            |
 | Update all packages (ignore dev)   | `poetry update --no-dev`        | Update all packages without the dev packages                                           |
 | Update selected packages           | `poetry update <package>`       | Update selected packages                                                               |
 | Lock packages                      | `poetry lock`                   | Lock the packages specified in `pyproject.toml`                                        |

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "onCommand:vscode-python-poetry.removePackage",
     "onCommand:vscode-python-poetry.removeDevPackageLegacy",
     "onCommand:vscode-python-poetry.updatePackages",
+    "onCommand:vscode-python-poetry.updatePackagesWithOptions",
     "onCommand:vscode-python-poetry.updatePackagesNoDev",
     "onCommand:vscode-python-poetry.updatePackage",
     "onCommand:vscode-python-poetry.lockPackages",
@@ -64,6 +65,11 @@
       {
         "command": "vscode-python-poetry.updatePackages",
         "title": "Update all packages",
+        "category": "Poetry"
+      },
+      {
+        "command": "vscode-python-poetry.updatePackagesWithOptions",
+        "title": "Update all packages (with options)",
         "category": "Poetry"
       },
       {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -39,6 +39,9 @@ export class Commands {
 
   updatePackages = () => this.poetryService.updatePackages();
 
+  updatePackagesWithOptions = () =>
+    this.poetryService.updatePackages({ askOptions: true });
+
   updatePackagesNoDev = () =>
     this.poetryService.updatePackages({ noDev: true });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,10 @@ export function activate(context: ExtensionContext): void {
         poetryCommands.updatePackages
       ),
       commands.registerCommand(
+        "vscode-python-poetry.updatePackagesWithOptions",
+        poetryCommands.updatePackagesWithOptions
+      ),
+      commands.registerCommand(
         "vscode-python-poetry.updatePackagesNoDev",
         poetryCommands.updatePackagesNoDev
       ),

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -79,6 +79,12 @@ suite("Commands", () => {
     assert.calledOnce(updatePackages);
   });
 
+  test("update packages with options", async () => {
+    const updatePackages = mockUpdatePackages();
+    await commands.updatePackagesWithOptions();
+    assert.calledWith(updatePackages, { askOptions: true });
+  });
+
   test("update packages no dev", async () => {
     const updatePackages = mockUpdatePackages();
     await commands.updatePackagesNoDev();


### PR DESCRIPTION
- Add `--without` and `--only` options support to `poetry update` command
- Close #197 
- Close #198 